### PR TITLE
fix: resolve release tag outside checkout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
           RELEASE_TAG: ${{ inputs.release_tag }}
         run: |
           [[ "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]]
-          release_sha=$(gh release view "$RELEASE_TAG" --json targetCommitish --jq .targetCommitish)
+          release_sha=$(gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --json targetCommitish --jq .targetCommitish)
           [[ "$release_sha" =~ ^[0-9a-f]{40}$ ]]
           echo "created=true" >> "$GITHUB_OUTPUT"
           echo "tag=$RELEASE_TAG" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Pass the repository explicitly when resolving an existing release in a workflow_dispatch run, where no checkout exists yet.