### PR TITLE
fix: upgrade container pip to patched release

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -6,7 +6,8 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 WORKDIR /app
 
 COPY requirements.txt ./
-RUN pip install --no-cache-dir --requirement requirements.txt
+RUN python -m pip install --no-cache-dir --upgrade "pip>=26.1.2" \
+    && python -m pip install --no-cache-dir --requirement requirements.txt
 
 RUN addgroup --system app && adduser --system --ingroup app app
 


### PR DESCRIPTION
## Security fix
- upgrade pip in the backend runtime image to 26.1.2 or newer before installing application dependencies
- resolves the Trivy HIGH gate for CVE-2026-8643 inherited from python:3.12-slim

This patch is intended for the v1.1.1 release because the existing v1.1.0 tag is immutable.