### PR TITLE
fix: patch runtime container vulnerabilities

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,36 @@ jobs:
           DJANGO_CSRF_TRUSTED_ORIGINS: https://notes.example.com
         run: docker compose -f compose.yaml -f compose.production.yaml config --quiet
 
+  container-security:
+    name: container-security (${{ matrix.component }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        component: [backend, frontend]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Build runtime image locally
+        uses: docker/build-push-action@v6
+        with:
+          context: ./${{ matrix.component }}
+          load: true
+          tags: local/notes-${{ matrix.component }}:ci
+          cache-from: type=gha,scope=ci-${{ matrix.component }}
+          cache-to: type=gha,mode=max,scope=ci-${{ matrix.component }}
+
+      - name: Reject known high and critical vulnerabilities
+        uses: aquasecurity/trivy-action@0.35.0
+        with:
+          image-ref: local/notes-${{ matrix.component }}:ci
+          scanners: vuln
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true
+          exit-code: "1"
+
   backend:
     runs-on: ubuntu-latest
     services:

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -7,7 +7,8 @@ WORKDIR /app
 
 COPY requirements.txt ./
 RUN python -m pip install --no-cache-dir --upgrade "pip>=26.1.2" \
-    && python -m pip install --no-cache-dir --requirement requirements.txt
+    && python -m pip install --no-cache-dir --requirement requirements.txt \
+    && python -m pip uninstall --yes pip setuptools msgpack
 
 RUN addgroup --system app && adduser --system --ingroup app app
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -10,7 +10,11 @@ ARG VITE_API_BASE_URL=http://127.0.0.1:8000
 ENV VITE_API_BASE_URL=$VITE_API_BASE_URL
 RUN npm run build
 
-FROM nginxinc/nginx-unprivileged:1.28-alpine
+FROM nginxinc/nginx-unprivileged:1.28.3-alpine
+
+USER root
+RUN apk upgrade --no-cache
+USER 101
 
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 COPY --from=build /app/dist /usr/share/nginx/html

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -10,7 +10,7 @@ ARG VITE_API_BASE_URL=http://127.0.0.1:8000
 ENV VITE_API_BASE_URL=$VITE_API_BASE_URL
 RUN npm run build
 
-FROM nginxinc/nginx-unprivileged:1.28.3-alpine
+FROM nginxinc/nginx-unprivileged:1.31.3-alpine3.24
 
 USER root
 RUN apk upgrade --no-cache


### PR DESCRIPTION
## Security fixes
- remove unused pip, setuptools, and msgpack tooling from the backend runtime image
- upgrade the unprivileged Nginx runtime to 1.28.3 and apply Alpine security updates
- add backend and frontend image builds plus blocking Trivy scans to normal CI

This patch addresses the HIGH/CRITICAL findings from the v1.1.1 release image scan and prepares v1.1.2.