### PR TITLE
fix: allow release provenance attestations

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,6 +67,7 @@ jobs:
     if: needs.release.outputs.created == 'true'
     runs-on: ubuntu-latest
     permissions:
+      attestations: write
       contents: read
       packages: write
       id-token: write


### PR DESCRIPTION
## Summary
- grant the release image job the narrowly scoped attestations: write permission
- unblock actions/attest-build-provenance for backend and frontend GHCR images

## Verification
- workflow syntax and diff validation completed locally
- protected-branch CI will validate the release workflow before merge