### PR TITLE
fix: require explicit production deployment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,7 +140,8 @@ jobs:
     needs: [release, images]
     if: >-
       needs.release.outputs.created == 'true' &&
-      (github.event_name != 'workflow_dispatch' || inputs.deploy)
+      github.event_name == 'workflow_dispatch' &&
+      inputs.deploy
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,3 +1,22 @@
+# License
+
+**React Django Notes App**
+
+Copyright 2023–2026 Fatma Kahveci
+
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not
+use this project except in compliance with the License. You may obtain a copy
+of the License at <https://www.apache.org/licenses/LICENSE-2.0>.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations.
+
+The complete license text follows.
+
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/


### PR DESCRIPTION
## Summary
- run production deployment only for an explicit manual dispatch with deploy=true
- prevent published releases from failing when production credentials are intentionally absent
- add project ownership and SPDX metadata to LICENSE.md while preserving the complete Apache 2.0 text

## Verification
- workflow and Markdown diffs pass whitespace validation
- protected-branch CI will verify the complete application and container security suite